### PR TITLE
v2.1.2 - Minor styling updates to Entrylist Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "acc-admin-tools",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "@angular/animations": "~13.1.0",
         "@angular/cdk": "^13.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/entrylist-editor/entrylist-editor.component.html
+++ b/src/app/entrylist-editor/entrylist-editor.component.html
@@ -363,8 +363,8 @@
 
     <div class="flex-vert">
       <!-- <span style="text-align: center;">Enable Grid Order? <mat-slide-toggle [checked]="showOrdered" (change)="gridOrderToggle($event)"></mat-slide-toggle></span> -->
-      <button mat-raised-button color="secondary" class="vert-button" (click)="createDriver()">Add New Driver</button>
-      <button mat-raised-button color="secondary" class="vert-button" (click)="gridOrderToggle()">{{showOrdered ? "Disable" : "Enable" }} Grid Order?</button>
+      <button mat-raised-button color="secondary" class="vert-button" (click)="createDriver()"><mat-icon>add</mat-icon> New Driver</button>
+      <button mat-raised-button color="secondary" class="vert-button" (click)="gridOrderToggle()"><mat-icon>123</mat-icon> {{showOrdered ? "Disable" : "Enable" }} Grid Order?</button>
       <mat-divider class="my-2"></mat-divider>
       <div class="small-split">
         <div class="drag-column" [ngStyle]="showOrdered ? {'display': 'block'} : {'display': 'none'}">

--- a/src/app/entrylist-editor/entrylist-editor.component.scss
+++ b/src/app/entrylist-editor/entrylist-editor.component.scss
@@ -21,7 +21,7 @@ p {
 .split {
     width: 60%;
     // border-right: 2px solid #3E3E40;
-    padding: 2.5%;
+    padding: 2%;
     padding-top: 1%
 }
 
@@ -32,7 +32,8 @@ p {
     flex-direction: row;
     overflow: auto;
     padding: 2.5%;
-    padding-top: 1%
+    padding-top: 1%;
+    min-height: 80vh;
 }
 
 .json-out {

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -236,6 +236,7 @@ export class EntrylistEditorComponent implements OnInit {
       driverCategory: [null],
       steamId: [''],
       customCarName: '',
+      teamName: '',
       raceNumber: [''],
       nationality: [0],
       carChoice: null,
@@ -261,6 +262,7 @@ export class EntrylistEditorComponent implements OnInit {
       driverCategory: driver.driverCategory,
       steamId: driver.playerID.substring(1),
       customCarName: entry.customCar,
+      teamName: entry.teamName,
       raceNumber: entry.raceNumber,
       nationality: driver.nationality,
       carChoice: entry.forcedCarModel,
@@ -538,6 +540,8 @@ export class EntrylistEditorComponent implements OnInit {
       'S' + this.form.get('steamId').value;
     this.json.entries[this.driverIndex].customCar =
       this.form.get('customCarName').value;
+    this.json.entries[this.driverIndex].teamName = 
+      this.form.get('teamName').value;
     this.json.entries[this.driverIndex].raceNumber =
       this.form.get('raceNumber').value;
     this.json.entries[this.driverIndex].drivers[0].nationality =

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -500,7 +500,9 @@ export class EntrylistEditorComponent implements OnInit {
         x -= 1;
       }
     })
-    this.patchByIndex(deleteIndex)
+    console.table(this.json.entries[deleteIndex])
+    console.log(this.json.entries.length)
+    this.patchByIndex(this.unorderedDrivers[0])
     this.getDriverOrders()
     //remove currently selected driver
     //if last driver in json, do createDriver() or not allow deletion of last driver

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -502,7 +502,7 @@ export class EntrylistEditorComponent implements OnInit {
     })
     console.table(this.json.entries[deleteIndex])
     console.log(this.json.entries.length)
-    this.patchByIndex(this.unorderedDrivers[0])
+    this.patchByIndex(this.unorderedDrivers[0] ?? this.orderedDrivers[0])
     this.getDriverOrders()
     //remove currently selected driver
     //if last driver in json, do createDriver() or not allow deletion of last driver

--- a/src/app/shared/modals/reset-confirmation/reset-confirmation.component.html
+++ b/src/app/shared/modals/reset-confirmation/reset-confirmation.component.html
@@ -1,5 +1,5 @@
 Are you sure you want to start again?<br>All edits made to this file will be lost!
 <div class="button-group btm">
-    <button mat-stroked-button color="primary" status="default" size="small" (click)="cancel()">Cancel</button>
+    <button mat-stroked-button color="warn" status="default" size="small" (click)="cancel()">Cancel</button>
     <button mat-flat-button color="primary" (click)="confirm()">Yes</button>
 </div>


### PR DESCRIPTION
# PATCHNOTES

## Race Results Tool
No Updates

## Server Files Creator
No Updates

## Entry List Editor
- Updated output json to include fields that may cause third-party server programs to error
- Updated the delete function to select the first driver in the unordered list (or ordered list if one exists)
- Changed colour of cancel button on the reset modal
- Minor styling updates throughout the page

## General Edits
No Updates

---

# CHECK BEFORE MERGING
- [x] Any unnecessary `console.log()` statements are removed.
- [x] Version Number in `package.json` is up to date.
- [x] Code conforms to previous standards set.
- [x] Testing has been carried out on the changes.