### PR TITLE
v2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acc-admin-tools",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@angular/animations": "~13.1.0",
         "@angular/cdk": "^13.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -437,6 +437,7 @@ export class EntrylistEditorComponent implements OnInit {
   fileHandler(file: File) {
     if (file) {
       this.loading = true;
+      this.doAdminsExist = false;
 
       const fileReader = new FileReader();
       fileReader.readAsText(file, 'UTF-8');
@@ -480,6 +481,7 @@ export class EntrylistEditorComponent implements OnInit {
 
     this.driverLength = this.json.entries.length;
     this.patchForm(0);
+    this.doAdminsExist = false;
     this.loading = false;
   }
 

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -345,6 +345,7 @@ export class EntrylistEditorComponent implements OnInit {
   }
 
   getDriverOrders() {
+    this.doAdminsExist = false;
     let tempJSON = this.json;
 
     this.unorderedDrivers = tempJSON.entries.map((entry, index) => {
@@ -438,6 +439,7 @@ export class EntrylistEditorComponent implements OnInit {
     if (file) {
       this.loading = true;
       this.doAdminsExist = false;
+      this.showAdmins = false;
 
       const fileReader = new FileReader();
       fileReader.readAsText(file, 'UTF-8');
@@ -482,6 +484,7 @@ export class EntrylistEditorComponent implements OnInit {
     this.driverLength = this.json.entries.length;
     this.patchForm(0);
     this.doAdminsExist = false;
+    this.showAdmins = false;
     this.loading = false;
   }
 


### PR DESCRIPTION
# PATCHNOTES

## Race Results Tool
No Updates

## Server Files Creator
No Updates

## Entry List Editor
- The ShowAdmins flag is not being reset on starting a new Entrylist without reloading
- The ShowAdmins flag is not being checked upon deleting all admins

## General Edits
No Updates

---

# CHECK BEFORE MERGING
- [x] Any unnecessary `console.log()` statements are removed.
- [x] Version Number in `package.json` is up to date.
- [x] Code conforms to previous standards set.
- [x] Testing has been carried out on the changes.