### PR TITLE
v2.4.0 - Copy/Paste Support for Entrylist-Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acc-admin-tools",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "dependencies": {
         "@angular/animations": "~13.1.0",
         "@angular/cdk": "^13.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/entrylist-editor/entrylist-editor.component.html
+++ b/src/app/entrylist-editor/entrylist-editor.component.html
@@ -5,6 +5,16 @@
     <h1 class="title">Upload your entrylist.json here</h1>
     <app-drag-over (fileEmitter)="fileHandler($event)" *ngIf="!loading && !json">
     </app-drag-over>
+    <div class="clipboard-paste" [formGroup]="inputForm">
+      <ng-container>
+        <input matInput formControlName="input" placeholder="Paste entrylist here..."/>
+      </ng-container>
+      <button
+        class="from-clipboard-button"
+        mat-stroked-button
+        color="accent"
+        (click)="newFile(this.inputForm.get('input').value)"><i class="fa-solid fa-clipboard-list"></i> Create from Clipboard</button>
+    </div>
     <button
       class="upload-button"
       mat-raised-button
@@ -408,6 +418,7 @@
               {{ getDriverByIndex(item).defaultGridPosition }}
             </div>
             <div class="driver-name">
+              <mat-icon class="admin-inline" *ngIf="hasAdminRole(item)" >admin_panel_settings</mat-icon>
               {{ getDriverFirstName(item) }}. 
               {{ getDriverLastName(item) }}
             </div>
@@ -447,6 +458,7 @@
               [cdkDragDisabled]="isAdmin(item) || dragDisabled"
             >
               <div class="driver-name">
+                <mat-icon class="admin-inline" *ngIf="hasAdminRole(item)" >admin_panel_settings</mat-icon> 
                 {{ getDriverFirstName(item) }}. 
                 {{ getDriverLastName(item) }}
               </div>

--- a/src/app/entrylist-editor/entrylist-editor.component.scss
+++ b/src/app/entrylist-editor/entrylist-editor.component.scss
@@ -227,15 +227,50 @@ p {
     padding-top: 10px;
 }
 
+.clipboard-paste {
+    display: flex;    
+    flex-direction: row;
+    width: 35%;
+    margin: 8px;
+    padding: 8px 0;
+    border-top: 1px solid rgb(133, 133, 133);
+    border-bottom: 1px solid rgb(133, 133, 133);
+    align-items: center;
+
+    input {
+        width: 63%;
+        margin-right: 2%;
+        height: 80%;
+        display:block !important;
+        background-color: transparent;
+        border: none;
+    }
+}
+
+.admin-inline {
+    // font-size: 14px;
+    width: 14px;
+    height: 14px;
+    line-height: 14px !important;
+    vertical-align:middle;
+    margin-right: 10px;
+}
+
+.from-clipboard-button {
+    width: 35%;
+    height: 100%;
+    border-color: rgb(133, 133, 133);
+}
+
 .upload-button {
     display: flexbox;
     position: relative;
+    justify-content: center;
+    align-items: center;
     text-align: center;
     height: 50px;
     width: 35%;
     margin: 4px 0px;
-    align-items: center;
-    justify-content: center;
 }
 
 .vert-button {

--- a/src/app/shared/drag-over/drag-over.component.ts
+++ b/src/app/shared/drag-over/drag-over.component.ts
@@ -32,7 +32,7 @@ export class DragOverComponent implements OnInit {
   }
 
   onFileSelected(event: any) {
-    console.log(event.target.files)
+    // console.log(event.target.files)
     const files: FileList = event.target.files;
 
     this.fileHandler(files)


### PR DESCRIPTION
# PATCHNOTES

## Race Results Tool
No Updates

## Server Files Creator
No Updates

## Entry List Editor

- Copy/Paste Support on creation
- Added Admin shield icons for users who have server admin permissions
- Adjusted logic for checking for non-driver admins

## General Edits
No Updates

---

# CHECK BEFORE MERGING
- [x] Any unnecessary `console.log()` statements are removed.
- [x] Version Number in `package.json` is up to date.
- [x] Code conforms to previous standards set.
- [x] Testing has been carried out on the changes.