### PR TITLE
v2.4.1 - Minor Entrylist Editor fixes + New Homepage Text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acc-admin-tools",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@angular/animations": "~13.1.0",
         "@angular/cdk": "^13.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acc-admin-tools",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -845,11 +845,11 @@ export class EntrylistEditorComponent implements OnInit {
         [this.orderedDrivers[i], this.orderedDrivers[j]] = [this.orderedDrivers[j], this.orderedDrivers[i]];
       }
 
-      for(let i = 0; i < this.orderedDrivers.length; i++) {
-        console.log(`Iterator: ${i} - Position #${this.orderedDrivers[i]}`)
-        this.json.entries[this.orderedDrivers[i]].defaultGridPosition = i + 1
-        console.log("Success")
-      }
+      // for(let i = 0; i < this.orderedDrivers.length; i++) {
+      //   console.log(`Iterator: ${i} - Position #${this.orderedDrivers[i]}`)
+      //   this.json.entries[this.orderedDrivers[i]].defaultGridPosition = i + 1
+      //   console.log("Success")
+      // }
     });
   }
 }

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -355,7 +355,7 @@ export class EntrylistEditorComponent implements OnInit {
     let tempJSON = this.json;
 
     this.unorderedDrivers = tempJSON.entries.map((entry, index) => {
-      if ((<number>entry.defaultGridPosition == undefined || <number>entry.forcedCarModel == undefined) && entry.isServerAdmin) {
+      if (entry.forcedCarModel == undefined && entry.isServerAdmin == 1) {
         this.doAdminsExist = true;
         this.handleSimGridAdmin(tempJSON, index)
         if(this.showAdmins) return index;
@@ -485,7 +485,23 @@ export class EntrylistEditorComponent implements OnInit {
     this.doAdminsExist = false;
     if(!input) {
       this.json = JSON.parse('{"entries": [],"forceEntryList": 1}');
-      this.createDriver();
+      this.json.entries.push({
+        drivers: [
+          {
+            firstName: '',
+            lastName: '',
+            shortName: '',
+            driverCategory: null,
+            nationality: null,
+            playerID: '',
+          },
+        ],
+        raceNumber: null,
+        forcedCarModel: -1,
+        overrideDriverInfo: 1,
+        defaultGridPosition: -1,
+        isServerAdmin: 0,
+      });
       this.getDriverOrders();
       this.driverLength = 1;
     }
@@ -499,6 +515,7 @@ export class EntrylistEditorComponent implements OnInit {
       this.toastr.error('Error with the entrylist, please try again.');
     }
     
+    this.patchByIndex(0);
     this.output = JSON.stringify(this.json, null, '\t');
     this.form.patchValue({
       output: this.output,
@@ -700,8 +717,7 @@ export class EntrylistEditorComponent implements OnInit {
     this.json.entries[this.driverIndex].drivers[0].nationality =
       this.form.get('nationality').value;
     this.json.entries[this.driverIndex].forcedCarModel =
-      this.form.get('carChoice').value 
-      ?? -1;
+      this.form.get('carChoice').value;
     this.json.entries[this.driverIndex].overrideDriverInfo = this.form.get(
       'overrideDriverInfo'
     ).value
@@ -829,11 +845,11 @@ export class EntrylistEditorComponent implements OnInit {
         [this.orderedDrivers[i], this.orderedDrivers[j]] = [this.orderedDrivers[j], this.orderedDrivers[i]];
       }
 
-      // for(let i = 0; i < this.orderedDrivers.length; i++) {
-      //   console.log(`Iterator: ${i} - Position #${this.orderedDrivers[i]}`)
-      //   this.json.entries[this.orderedDrivers[i]].defaultGridPosition = i + 1
-      //   console.log("Success")
-      // }
+      for(let i = 0; i < this.orderedDrivers.length; i++) {
+        console.log(`Iterator: ${i} - Position #${this.orderedDrivers[i]}`)
+        this.json.entries[this.orderedDrivers[i]].defaultGridPosition = i + 1
+        console.log("Success")
+      }
     });
   }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -6,7 +6,7 @@
 >
   <div class="wrapper">
     <h1 class="title">Welcome to ACC Admin Tools</h1>
-    <h3 class="title">Useful for server hosting and such</h3>
+    <h3 class="title">Tools for working with server files for ACC Server Hosting</h3>
     <label class="title">By Marley Watts - @brexite</label>
 
     <div id="myDropdown" class="socials">

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -7,7 +7,7 @@
   <div class="wrapper">
     <h1 class="title">Welcome to ACC Admin Tools</h1>
     <h3 class="title">Tools for working with server files for ACC Server Hosting</h3>
-    <label class="title">By Marley Watts - @brexite</label>
+    <label class="title">By Marley Watts - @brexite - v{{version}}</label>
 
     <div id="myDropdown" class="socials">
       <a href="https://github.com/brexite/ACC-Admin-Tools" target="_blank"

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -38,10 +38,14 @@ h2 {
   min-width: 48px;
   transition: transform 0.2s;
   pointer-events: all;
+  i {
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  }
 }
 
 .title {
   display: flexbox;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
 mat-spinner {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { fadeInOut } from "../shared/animations/animations";
 import { Clipboard } from '@angular/cdk/clipboard';
+import packageJson  from '../../../package.json';
 
 @Component({
   selector: 'app-home',
@@ -14,6 +15,7 @@ export class HomeComponent implements OnInit {
   outputForm: FormGroup;
   loading: boolean = true;
   output: string;
+  version: string = packageJson.version;
 
   bg = [
     './assets/bg0.png',

--- a/src/app/shared/modals/textarea-modal/textarea-modal.component.ts
+++ b/src/app/shared/modals/textarea-modal/textarea-modal.component.ts
@@ -19,7 +19,7 @@ export class TextareaModalComponent {
         private toastr: ToastrService,
     ) 
     { 
-        console.log(data)
+        // console.log(data)
         this.output = JSON.stringify(data.json, null, "\t")
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
     "target": "es2017",
     "module": "es2020",
     "lib": [


### PR DESCRIPTION
# PATCHNOTES

## Race Results Tool
No Updates

## Server Files Creator
No Updates

## Entry List Editor
- Fixed creating a new entrylist creating an admin instead of a driver by default
- Fixed isAdmin including drivers who have server admin role
- Fixed pasting an entrylist defaulting to a blank form, causing one driver to be overwritten by blank data

## General Edits
- Updated homepage text to be less unprofessional
- Added version number to the homepage

---

# CHECK BEFORE MERGING
- [x] Any unnecessary `console.log()` statements are removed.
- [x] Version Number in `package.json` is up to date.
- [x] Code conforms to previous standards set.
- [x] Testing has been carried out on the changes.
- [x] Any updates to the .env have been added to the GitHub secrets and the merge pipeline.