### PR TITLE
v3.3.2 - Move server admins to end of entrylist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acc-admin-tools",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acc-admin-tools",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "dependencies": {
         "@angular/animations": "~13.1.0",
         "@angular/cdk": "^13.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acc-admin-tools",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/entrylist-editor/entrylist-editor.component.ts
+++ b/src/app/entrylist-editor/entrylist-editor.component.ts
@@ -504,8 +504,10 @@ export class EntrylistEditorComponent implements OnInit {
     });
 
     this.unorderedTeams.sort(function (a, b) {
-      if (tempJSON.entries[a].raceNumber == undefined) return -1;
-      if (tempJSON.entries[b].raceNumber == undefined) return 1;
+      if (tempJSON.entries[a].raceNumber == undefined || 
+        (tempJSON.entries[b].forcedCarModel == undefined && tempJSON.entries[b].isServerAdmin == 1)) return -1; // Move server admins to the end
+      if (tempJSON.entries[b].raceNumber == undefined ||
+        (tempJSON.entries[a].forcedCarModel == undefined && tempJSON.entries[a].isServerAdmin == 1)) return 1; // Move server admins to the end
       return tempJSON.entries[a].raceNumber - tempJSON.entries[b].raceNumber;
     });
 


### PR DESCRIPTION
# PATCHNOTES

## Race Results Tool
No Updates

## Server Files Creator
No Updates

## Entry List Editor
- Move server admins to end of entrylist.json to solve default grid slot issue if driver is defined as a server admin and as a driver

## General Edits
No Updates

---

# CHECK BEFORE MERGING
- [x] Any unnecessary `console.log()` statements are removed.
- [x] Version Number in `package.json` is up to date.
- [x] Code conforms to previous standards set.
- [x] Testing has been carried out on the changes.